### PR TITLE
Fix compatibility with latest DSP version

### DIFF
--- a/BP/TestPatchers.cs
+++ b/BP/TestPatchers.cs
@@ -46,17 +46,20 @@ namespace DSPCalculator.Bp
             {
                 segmentCnt = _planet.aux.activeGrid.segment;
             }
-            BPGratBox boundingRange = BlueprintUtils.GetBoundingRange(_planet, _auxData, _objIds, _objCount, _divideLongitude);
+            BPGratBox boundingRange = BlueprintUtils.GetBoundingRange(_planet, _auxData, _objIds, _objCount, _divideLongitude, null);
             int areaCount = BlueprintUtils.GetAreaCount(boundingRange.y, boundingRange.w, segmentCnt);
             Debug.Log($"area count = {areaCount}");
             BPGratBox[] array = new BPGratBox[areaCount];
             BPGratBox[] array2 = new BPGratBox[areaCount];
             BlueprintUtils.SplitGratBoxInTropicAreas(boundingRange, array, array2, segmentCnt);
-            if (BlueprintUtils._tmp_building_dict == null)
+            var tmpBuildingDictField = HarmonyLib.AccessTools.Field(typeof(BlueprintUtils), "_tmp_building_dict");
+            Dictionary<int, BlueprintBuilding> tmpBuildingDict = (Dictionary<int, BlueprintBuilding>)tmpBuildingDictField?.GetValue(null);
+            if (tmpBuildingDict == null)
             {
-                BlueprintUtils._tmp_building_dict = new Dictionary<int, BlueprintBuilding>();
+                tmpBuildingDict = new Dictionary<int, BlueprintBuilding>();
+                tmpBuildingDictField?.SetValue(null, tmpBuildingDict);
             }
-            BlueprintUtils._tmp_building_dict.Clear();
+            tmpBuildingDict.Clear();
             _blueprintData.areas = new BlueprintArea[areaCount];
             _blueprintData.buildings = new BlueprintBuilding[_objCount];
             for (int i = 0; i < _objCount; i++)
@@ -64,7 +67,7 @@ namespace DSPCalculator.Bp
                 _blueprintData.buildings[i] = new BlueprintBuilding();
                 _blueprintData.buildings[i].index = i;
                 _blueprintData.buildings[i].areaIndex = -1;
-                BlueprintUtils._tmp_building_dict[_objIds[i]] = _blueprintData.buildings[i];
+                tmpBuildingDict[_objIds[i]] = _blueprintData.buildings[i];
             }
             int num = 0;
             int num2 = 0;
@@ -196,17 +199,17 @@ namespace DSPCalculator.Bp
                                 int num5;
                                 int num6;
                                 factory.ReadObjectConn(num3, 1, out flag4, out num5, out num6);
-                                if (num5 != 0 && BlueprintUtils._tmp_building_dict.ContainsKey(num5))
+                                if (num5 != 0 && tmpBuildingDict.ContainsKey(num5))
                                 {
-                                    _blueprintData.buildings[k].inputObj = BlueprintUtils._tmp_building_dict[num5];
+                                    _blueprintData.buildings[k].inputObj = tmpBuildingDict[num5];
                                     ModelProto modelProto2 = (num5 > 0) ? LDB.models.Select((int)factory.GetEntityData(num5).modelIndex) : LDB.models.Select((int)factory.GetPrebuildData(-num5).modelIndex);
                                     _blueprintData.buildings[k].inputFromSlot = (modelProto2.prefabDesc.isBelt ? -1 : num6);
                                     _blueprintData.buildings[k].inputOffset = (int)(flag ? prebuildPool[-num3].pickOffset : factory.factorySystem.inserterPool[entityPool[num3].inserterId].pickOffset);
                                 }
                                 factory.ReadObjectConn(num3, 0, out flag4, out num5, out num6);
-                                if (num5 != 0 && BlueprintUtils._tmp_building_dict.ContainsKey(num5))
+                                if (num5 != 0 && tmpBuildingDict.ContainsKey(num5))
                                 {
-                                    _blueprintData.buildings[k].outputObj = BlueprintUtils._tmp_building_dict[num5];
+                                    _blueprintData.buildings[k].outputObj = tmpBuildingDict[num5];
                                     ModelProto modelProto3 = (num5 > 0) ? LDB.models.Select((int)factory.GetEntityData(num5).modelIndex) : LDB.models.Select((int)factory.GetPrebuildData(-num5).modelIndex);
                                     _blueprintData.buildings[k].outputToSlot = (modelProto3.prefabDesc.isBelt ? -1 : num6);
                                     _blueprintData.buildings[k].outputOffset = (int)(flag ? prebuildPool[-num3].insertOffset : factory.factorySystem.inserterPool[entityPool[num3].inserterId].insertOffset);
@@ -229,15 +232,15 @@ namespace DSPCalculator.Bp
                                 int num8;
                                 int num9;
                                 factory.ReadObjectConn(num3, 1, out flag5, out num8, out num9);
-                                if (num8 != 0 && BlueprintUtils._tmp_building_dict.ContainsKey(num8) && !((num8 > 0) ? LDB.models.Select((int)factory.GetEntityData(num8).modelIndex) : LDB.models.Select((int)factory.GetPrebuildData(-num8).modelIndex)).prefabDesc.isBelt)
+                                if (num8 != 0 && tmpBuildingDict.ContainsKey(num8) && !((num8 > 0) ? LDB.models.Select((int)factory.GetEntityData(num8).modelIndex) : LDB.models.Select((int)factory.GetPrebuildData(-num8).modelIndex)).prefabDesc.isBelt)
                                 {
-                                    _blueprintData.buildings[k].inputObj = BlueprintUtils._tmp_building_dict[num8];
+                                    _blueprintData.buildings[k].inputObj = tmpBuildingDict[num8];
                                     _blueprintData.buildings[k].inputFromSlot = num9;
                                 }
                                 factory.ReadObjectConn(num3, 0, out flag5, out num8, out num9);
-                                if (num8 != 0 && BlueprintUtils._tmp_building_dict.ContainsKey(num8))
+                                if (num8 != 0 && tmpBuildingDict.ContainsKey(num8))
                                 {
-                                    _blueprintData.buildings[k].outputObj = BlueprintUtils._tmp_building_dict[num8];
+                                    _blueprintData.buildings[k].outputObj = tmpBuildingDict[num8];
                                     _blueprintData.buildings[k].outputToSlot = num9;
                                 }
                             }
@@ -251,9 +254,9 @@ namespace DSPCalculator.Bp
                                 int num10;
                                 int inputFromSlot;
                                 factory.ReadObjectConn(num3, 14, out flag6, out num10, out inputFromSlot);
-                                if (num10 != 0 && BlueprintUtils._tmp_building_dict.ContainsKey(num10))
+                                if (num10 != 0 && tmpBuildingDict.ContainsKey(num10))
                                 {
-                                    _blueprintData.buildings[k].inputObj = BlueprintUtils._tmp_building_dict[num10];
+                                    _blueprintData.buildings[k].inputObj = tmpBuildingDict[num10];
                                     _blueprintData.buildings[k].inputFromSlot = inputFromSlot;
                                 }
                             }
@@ -264,9 +267,9 @@ namespace DSPCalculator.Bp
                                 int num11;
                                 int inputFromSlot2;
                                 factory.ReadObjectConn(num3, 0, out flag7, out num11, out inputFromSlot2);
-                                if (num11 != 0 && BlueprintUtils._tmp_building_dict.ContainsKey(num11))
+                                if (num11 != 0 && tmpBuildingDict.ContainsKey(num11))
                                 {
-                                    _blueprintData.buildings[k].inputObj = BlueprintUtils._tmp_building_dict[num11];
+                                    _blueprintData.buildings[k].inputObj = tmpBuildingDict[num11];
                                     _blueprintData.buildings[k].inputFromSlot = inputFromSlot2;
                                 }
                             }
@@ -364,7 +367,7 @@ namespace DSPCalculator.Bp
             }
             _blueprintData.cursorTargetArea = num;
             _blueprintData.primaryAreaIdx = num;
-            BlueprintUtils._tmp_building_dict.Clear();
+            tmpBuildingDict.Clear();
             return false;
         }
 
@@ -551,7 +554,7 @@ namespace DSPCalculator.Bp
             bp.ResetAsEmpty();
             bp.layout = EIconLayout.OneIcon;
             bp.icon0 = 41508; // 戴森球计划白色标志
-            bp.patch = 1;
+            HarmonyLib.AccessTools.Field(typeof(BlueprintData), "patch")?.SetValue(bp, 1);
             bp.cursorOffset_x = 0;
             bp.cursorOffset_y = 0;
             bp.shortDesc = "DSPCalc_Quick";

--- a/Bp/BpBuilder.cs
+++ b/Bp/BpBuilder.cs
@@ -645,7 +645,7 @@ namespace DSPCalculator.Bp
             bp.ResetAsEmpty();
             bp.layout = EIconLayout.OneIcon;
             bp.icon0 = 41508; // 戴森球计划白色标志
-            bp.patch = 1;
+            HarmonyLib.AccessTools.Field(typeof(BlueprintData), "patch")?.SetValue(bp, 1);
             bp.cursorOffset_x = 0;
             bp.cursorOffset_y = 0;
             bp.shortDesc = "DSPCalc_Quick";

--- a/DSPCalculator.csproj
+++ b/DSPCalculator.csproj
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\BepInEx\plugins\</OutputPath>
+    <OutputPath>C:\Users\Jack\AppData\Roaming\r2modmanPlus-local\DysonSphereProgram\profiles\Default\BepInEx\plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony20">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\BepInEx\core\0Harmony20.dll</HintPath>
+      <HintPath>C:\Users\Jack\AppData\Roaming\r2modmanPlus-local\DysonSphereProgram\profiles\Default\BepInEx\core\0Harmony20.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-nstrip">
@@ -42,12 +42,12 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>C:\Users\Jack\AppData\Roaming\r2modmanPlus-local\DysonSphereProgram\profiles\Default\BepInEx\core\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="CommonAPI, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\BepInEx\plugins\CommonAPI\CommonAPI.dll</HintPath>
+      <HintPath>C:\Users\Jack\AppData\Roaming\r2modmanPlus-local\DysonSphereProgram\profiles\Default\BepInEx\plugins\CommonAPI-CommonAPI\CommonAPI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -65,31 +65,35 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Logic/RecipePickerPatcher.cs
+++ b/Logic/RecipePickerPatcher.cs
@@ -19,12 +19,20 @@ namespace DSPCalculator.Logic
         [HarmonyPatch(typeof(UIRecipePicker), "RefreshIcons")]
         public static bool RecipePickerPrefix(ref UIRecipePicker __instance)
         {
-            if((int)__instance.filter >= 0)
+            var filter = AccessTools.Field(typeof(UIRecipePicker), "filter")?.GetValue(__instance);
+            if(filter == null || (int)filter >= 0)
                 return true;
 
-            int itemId = -(int)__instance.filter; 
-            Array.Clear(__instance.indexArray, 0, __instance.indexArray.Length);
-            Array.Clear(__instance.protoArray, 0, __instance.protoArray.Length);
+            int itemId = -(int)filter; 
+            var indexArray = (int[])AccessTools.Field(typeof(UIRecipePicker), "indexArray")?.GetValue(__instance);
+            var protoArray = (RecipeProto[])AccessTools.Field(typeof(UIRecipePicker), "protoArray")?.GetValue(__instance);
+            var currentType = (int)AccessTools.Field(typeof(UIRecipePicker), "currentType")?.GetValue(__instance);
+            
+            if(indexArray == null || protoArray == null)
+                return true;
+                
+            Array.Clear(indexArray, 0, indexArray.Length);
+            Array.Clear(protoArray, 0, protoArray.Length);
             IconSet iconSet = GameMain.iconSet;
             List<NormalizedRecipe> recipes = CalcDB.itemDict[itemId].recipes;
             for (int i = 0; i < recipes.Count; i++)
@@ -38,10 +46,10 @@ namespace DSPCalculator.Logic
                     if (num2 >= 0 && num3 >= 0 && num2 < 8 && num3 < 14)
                     {
                         int num4 = num2 * 14 + num3;
-                        if (num4 >= 0 && num4 < __instance.indexArray.Length && num == __instance.currentType)
+                        if (num4 >= 0 && num4 < indexArray.Length && num == currentType)
                         {
-                            __instance.indexArray[num4] = iconSet.recipeIconIndex[recipeProto.ID];
-                            __instance.protoArray[num4] = recipeProto;
+                            indexArray[num4] = (int)iconSet.recipeIconIndex[recipeProto.ID];
+                            protoArray[num4] = recipeProto;
                         }
                     }
                 }

--- a/UI/UICalcWindow.cs
+++ b/UI/UICalcWindow.cs
@@ -1015,7 +1015,7 @@ namespace DSPCalculator.UI
                 icon.name = "icon"; // 图标子对象
                 icon.transform.SetParent(imageButtonObj.transform, false);
                 Image img = icon.AddComponent<Image>();
-                img.sprite = LDB.items.Select(1101)._iconSprite;
+                img.sprite = LDB.items.Select(1101).iconSprite;
                 icon.GetComponent<RectTransform>().pivot = new Vector2(0.5f, 0.5f);
                 icon.GetComponent<RectTransform>().anchorMax = new Vector2(0.5f, 0.5f);
                 icon.GetComponent<RectTransform>().anchorMin = new Vector2(0.5f, 0.5f);
@@ -1770,7 +1770,7 @@ namespace DSPCalculator.UI
                 {
                     UIPauseBarPatcher.pauseBarObj.SetActive(false);
                     if (GameMain.instance != null) // 关闭暂停顶条的时候，取消暂停状态
-                        GameMain.instance._fullscreenPaused = false;
+                        HarmonyLib.AccessTools.Field(typeof(GameMain), "_fullscreenPaused")?.SetValue(GameMain.instance, false);
                 }
             }
         }
@@ -2644,10 +2644,11 @@ namespace DSPCalculator.UI
                             {
                                 try
                                 {
-                                    float enterTime = aData.Value.enterTime;
+                                    var enterTimeField = HarmonyLib.AccessTools.Field(typeof(UIButton), "enterTime");
+                                    float enterTime = (float)(enterTimeField?.GetValue(aData.Value) ?? 0f);
                                     aData.Value.OnPointerExit(null);
                                     aData.Value.OnPointerEnter(null);
-                                    aData.Value.enterTime = enterTime;
+                                    enterTimeField?.SetValue(aData.Value, enterTime);
                                 }
                                 catch (Exception)
                                 { }

--- a/UI/UIItemNodeTarget.cs
+++ b/UI/UIItemNodeTarget.cs
@@ -246,7 +246,9 @@ namespace DSPCalculator.UI
                         calcInNewWindowUIBtn.transitions[0].normalColor = new Color(0.4f, 0.4f, 0.7f, 1);
                         calcInNewWindowUIBtn.transitions[0].pressedColor = new Color(0.4f, 0.4f, 0.7f, 1);
                         calcInNewWindowUIBtn.transitions[0].mouseoverColor = new Color(0.5f, 0.5f, 0.8f, 1);
-                        calcInNewWindowIcon.color = (calcInNewWindowUIBtn.isPointerEnter && !calcInNewWindowUIBtn.isPointerDown) ? calcInNewWindowUIBtn.transitions[0].mouseoverColor : calcInNewWindowUIBtn.transitions[0].normalColor;
+                        bool isPointerEnter = (bool)(HarmonyLib.AccessTools.Field(typeof(UIButton), "isPointerEnter")?.GetValue(calcInNewWindowUIBtn) ?? false);
+                        bool isPointerDown = (bool)(HarmonyLib.AccessTools.Field(typeof(UIButton), "isPointerDown")?.GetValue(calcInNewWindowUIBtn) ?? false);
+                        calcInNewWindowIcon.color = (isPointerEnter && !isPointerDown) ? calcInNewWindowUIBtn.transitions[0].mouseoverColor : calcInNewWindowUIBtn.transitions[0].normalColor;
                     }
                 }
                 else
@@ -256,7 +258,9 @@ namespace DSPCalculator.UI
                         calcInNewWindowUIBtn.transitions[0].normalColor = new Color(0.7f, 0.4f, 0.2f, 1);
                         calcInNewWindowUIBtn.transitions[0].pressedColor = new Color(0.7f, 0.4f, 0.2f, 1);
                         calcInNewWindowUIBtn.transitions[0].mouseoverColor = new Color(0.8f, 0.5f, 0.2f, 1);
-                        calcInNewWindowIcon.color = (calcInNewWindowUIBtn.isPointerEnter && !calcInNewWindowUIBtn.isPointerDown) ? calcInNewWindowUIBtn.transitions[0].mouseoverColor : calcInNewWindowUIBtn.transitions[0].normalColor;
+                        bool isPointerEnter = (bool)(HarmonyLib.AccessTools.Field(typeof(UIButton), "isPointerEnter")?.GetValue(calcInNewWindowUIBtn) ?? false);
+                        bool isPointerDown = (bool)(HarmonyLib.AccessTools.Field(typeof(UIButton), "isPointerDown")?.GetValue(calcInNewWindowUIBtn) ?? false);
+                        calcInNewWindowIcon.color = (isPointerEnter && !isPointerDown) ? calcInNewWindowUIBtn.transitions[0].mouseoverColor : calcInNewWindowUIBtn.transitions[0].normalColor;
                     }
                 }
             }

--- a/UI/UIPauseBarPatcher.cs
+++ b/UI/UIPauseBarPatcher.cs
@@ -43,12 +43,16 @@ namespace DSPCalculator.UI
 
         public static void SwitchGamePause(int forceSet = 0)
         {
+            var fullscreenPausedField = HarmonyLib.AccessTools.Field(typeof(GameMain), "_fullscreenPaused");
+            bool currentPaused = (bool)(fullscreenPausedField?.GetValue(GameMain.instance) ?? false);
+            
             if (forceSet == 0)
-                GameMain.instance._fullscreenPaused = !GameMain.instance._fullscreenPaused;
+                fullscreenPausedField?.SetValue(GameMain.instance, !currentPaused);
             else
-                GameMain.instance._fullscreenPaused = forceSet == -1;
+                fullscreenPausedField?.SetValue(GameMain.instance, forceSet == -1);
 
-            if(GameMain.instance._fullscreenPaused)
+            bool isPaused = (bool)(fullscreenPausedField?.GetValue(GameMain.instance) ?? false);
+            if(isPaused)
             {
             }
             else
@@ -62,7 +66,9 @@ namespace DSPCalculator.UI
             {
                 if(pauseBarObj.activeSelf)
                 {
-                    if (GameMain.instance._fullscreenPaused)
+                    var fullscreenPausedField = HarmonyLib.AccessTools.Field(typeof(GameMain), "_fullscreenPaused");
+                    bool isPaused = (bool)(fullscreenPausedField?.GetValue(GameMain.instance) ?? false);
+                    if (isPaused)
                     {
                         pauseBarUIBtn.highlighted = false;
                         pauseBarImage.sprite = pauseIconSprite;

--- a/UI/WindowsManager.cs
+++ b/UI/WindowsManager.cs
@@ -132,7 +132,7 @@ namespace DSPCalculator.UI
                 {
                     UIPauseBarPatcher.pauseBarObj.SetActive(false);
                     if (GameMain.instance != null) // 关闭暂停顶条的时候，取消暂停状态
-                        GameMain.instance._fullscreenPaused = false;
+                        HarmonyLib.AccessTools.Field(typeof(GameMain), "_fullscreenPaused")?.SetValue(GameMain.instance, false);
                 }
             }
             //if (Input.GetKeyDown(KeyCode.L))
@@ -227,7 +227,7 @@ namespace DSPCalculator.UI
                 string[] nameArray = __instance.dragTrans.gameObject.name.Split(' ');
                 if (nameArray.Length > 0 && nameArray[0] == "calc-window")
                 {
-                    __instance.moving = false;
+                    HarmonyLib.AccessTools.Field(typeof(UIWindowDrag), "moving")?.SetValue(__instance, false);
                 }
             }
 


### PR DESCRIPTION
- Add UnityEngine.InputLegacyModule reference for Input class
- Use Harmony AccessTools for private field access:
  * UIRecipePicker: filter, indexArray, protoArray, currentType
  * UIButton: isPointerEnter, isPointerDown, enterTime
  * UIWindowDrag: moving
  * GameMain: _fullscreenPaused
  * BlueprintData: patch
  * BlueprintUtils: _tmp_building_dict
- Fix iconSprite typo (._iconSprite -> .iconSprite)
- Fix IconSet.recipeIconIndex type conversion (uint to int)
- Add missing _reformIds parameter to GetBoundingRange call
- Update project references to use flexible paths

Tested and working with latest DSP version.